### PR TITLE
[REFACTOR] Move time utils functions

### DIFF
--- a/src/commands/edt.ts
+++ b/src/commands/edt.ts
@@ -1,16 +1,7 @@
 import {  CommandInteraction, ApplicationCommandOptionType, EmbedBuilder } from 'discord.js';
 import { getAvailableClassroom } from '../utils/ade';
-import { convertDateFormat, isValidDate, isValidTime } from '../utils/date';
-
-const add1Hour = (hour: string) => {
-    const [h, m] = hour.split(":").map(Number);
-    const newHourDate = new Date();
-
-    newHourDate.setHours(h);
-    newHourDate.setMinutes(m + 60);
-
-    return newHourDate.toLocaleTimeString("fr-FR", { hour: "2-digit", minute: "2-digit" });
-};
+import { convertDateFormat, isValidDate } from '../utils/date';
+import { isValidTime, add1Hour } from '../utils/time';
 
 export const edt = {
     name: "edt",

--- a/src/utils/ade.ts
+++ b/src/utils/ade.ts
@@ -1,6 +1,6 @@
 import { ADEPlanningAPI } from "ade-planning-api";
 import { sleep } from "./sleep";
-import { doTimeRangeOverlap } from "./date";
+import { doTimeRangeOverlap } from "./time";
 
 export const getAvailableClassroom = async (date: string, startHour: string, endHour: string) => {
     const api = new ADEPlanningAPI(process.env.ADE_LINK as string);

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -4,21 +4,6 @@ export const convertDateFormat = (date: string) => {
     return `${month}/${day}/${year}`;
 };
 
-export const doTimeRangeOverlap = (start1: string, end1: string, start2: string, end2: string) => {
-    const timeToMinutes = (time: string) => {
-        const [hours, minutes] = time.split(':').map(Number);
-
-        return hours * 60 + minutes;
-    }
-
-    const start1Minutes = timeToMinutes(start1);
-    const end1Minutes = timeToMinutes(end1);
-    const start2Minutes = timeToMinutes(start2);
-    const end2Minutes = timeToMinutes(end2);
-
-    return start1Minutes < end2Minutes && start2Minutes < end1Minutes;
-};
-
 export const isValidDate = (date: string) => {
     const parts = date.split('/').map(Number);
 
@@ -37,16 +22,3 @@ export const isValidDate = (date: string) => {
     return dateObj.getDate() === parts[0] && dateObj.getMonth() === parts[1] && dateObj.getFullYear() === parts[2]; // Check if date is valid
 }
 
-export const isValidTime = (time: string) => {
-    const parts = time.split(':').map(Number);
-
-    if (parts.length !== 2) {
-        return false;
-    }
-
-    if (isNaN(parts[0]) || isNaN(parts[1])) {
-        return false;
-    }
-
-    return parts[0] >= 0 && parts[0] <= 23 && parts[1] >= 0 && parts[1] <= 59;
-};

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,10 +1,4 @@
 export const doTimeRangeOverlap = (start1: string, end1: string, start2: string, end2: string) => {
-    const timeToMinutes = (time: string) => {
-        const [hours, minutes] = time.split(':').map(Number);
-
-        return hours * 60 + minutes;
-    }
-
     const start1Minutes = timeToMinutes(start1);
     const end1Minutes = timeToMinutes(end1);
     const start2Minutes = timeToMinutes(start2);
@@ -12,3 +6,9 @@ export const doTimeRangeOverlap = (start1: string, end1: string, start2: string,
 
     return start1Minutes < end2Minutes && start2Minutes < end1Minutes;
 };
+
+export const timeToMinutes = (time: string) => {
+    const [hours, minutes] = time.split(':').map(Number);
+
+    return hours * 60 + minutes;
+}

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -12,3 +12,17 @@ export const timeToMinutes = (time: string) => {
 
     return hours * 60 + minutes;
 }
+
+export const isValidTime = (time: string) => {
+    const parts = time.split(':').map(Number);
+
+    if (parts.length !== 2) {
+        return false;
+    }
+
+    if (isNaN(parts[0]) || isNaN(parts[1])) {
+        return false;
+    }
+
+    return parts[0] >= 0 && parts[0] <= 23 && parts[1] >= 0 && parts[1] <= 59;
+};

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,0 +1,14 @@
+export const doTimeRangeOverlap = (start1: string, end1: string, start2: string, end2: string) => {
+    const timeToMinutes = (time: string) => {
+        const [hours, minutes] = time.split(':').map(Number);
+
+        return hours * 60 + minutes;
+    }
+
+    const start1Minutes = timeToMinutes(start1);
+    const end1Minutes = timeToMinutes(end1);
+    const start2Minutes = timeToMinutes(start2);
+    const end2Minutes = timeToMinutes(end2);
+
+    return start1Minutes < end2Minutes && start2Minutes < end1Minutes;
+};

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -26,3 +26,13 @@ export const isValidTime = (time: string) => {
 
     return parts[0] >= 0 && parts[0] <= 23 && parts[1] >= 0 && parts[1] <= 59;
 };
+
+export const add1Hour = (hour: string) => {
+    const [h, m] = hour.split(":").map(Number);
+    const newHourDate = new Date();
+
+    newHourDate.setHours(h);
+    newHourDate.setMinutes(m + 60);
+
+    return newHourDate.toLocaleTimeString("fr-FR", { hour: "2-digit", minute: "2-digit" });
+};


### PR DESCRIPTION
This pull request includes several changes to improve the organization of utility functions in the codebase. The most important changes involve moving time-related functions from `src/utils/date.ts` to a new file `src/utils/time.ts`, and updating the corresponding imports across the project.

### Refactoring of utility functions:

* Moved `add1Hour`, `doTimeRangeOverlap`, and `isValidTime` functions from `src/utils/date.ts` to `src/utils/time.ts`. [[1]](diffhunk://#diff-10baaa420455f75556cb3f2ab221bd12171abf0c582942a5b0201fd86b784c8aL7-L21) [[2]](diffhunk://#diff-10baaa420455f75556cb3f2ab221bd12171abf0c582942a5b0201fd86b784c8aL40-L52) [[3]](diffhunk://#diff-38e47b4eeea96b1634986e199da0917411a0e085aeab0a6949875cd6e7b7bee7R1-R38)
* Updated imports in `src/commands/edt.ts` to reflect the new location of the `add1Hour` and `isValidTime` functions.
* Updated imports in `src/utils/ade.ts` to reflect the new location of the `doTimeRangeOverlap` function.