### PR TITLE
[FIX] Change startHour comparison

### DIFF
--- a/src/commands/recherche_salles.ts
+++ b/src/commands/recherche_salles.ts
@@ -56,7 +56,7 @@ export const recherche_salles = {
             return;
         }
 
-        if (startHourString >= endHourString) {
+        if (convertTimeToString(startHour) >= convertTimeToString(endHour)) {
             await sendErrorEmbed(interaction, ERROR_START_AFTER_END);
             return;
         }


### PR DESCRIPTION
This pull request includes a change to the `src/commands/recherche_salles.ts` file to improve the time comparison logic. The most important change is:

* [`src/commands/recherche_salles.ts`](diffhunk://#diff-4ab74d494a9beb140ae2779cfd76cac979c2962af08aa9f531eda704ee61b81cL59-R59): Modified the condition to compare `startHour` and `endHour` by converting them to strings using the `convertTimeToString` function instead of directly comparing `startHourString` and `endHourString`.